### PR TITLE
Finalized MVP tower and creep logic

### DIFF
--- a/revelations/client/src/Game/Animator/index.js
+++ b/revelations/client/src/Game/Animator/index.js
@@ -42,7 +42,6 @@ function Animator(props){
     // Call when props.fireCount is changed
     useEffect(() => {
         if(props.startAnimation && !isAnimating){
-            console.log("starting animation");
             requestAnimationFrame(() => toggleAnimation(true));
         }
     });

--- a/revelations/client/src/Game/TowerLayer/index.js
+++ b/revelations/client/src/Game/TowerLayer/index.js
@@ -24,7 +24,6 @@ function TowerLayer(props){
                 // Retrieve sprite
                 const imgData = SpriteEnums[entry[1].data.spriteSheet];
                 const animFlag = state.animationState.towers.includes(parseInt(entry[0]));
-                if(animFlag) console.log("Animating!");
                 return <Animator 
                           height={state.gameState.mapGrid.cellsize} 
                           width={state.gameState.mapGrid.cellsize} 

--- a/revelations/client/src/engine/GameEnums.js
+++ b/revelations/client/src/engine/GameEnums.js
@@ -48,7 +48,18 @@ export default {
      * @type {Object.<number, Array.<creepBatch>>}
      */
     WAVE_CONFIG: {
-        0: [{ creeps: ["test_creep","test_creep"], delay: 5000}] 
+        0: [
+            { creeps: ["test_creep","test_creep"], delay: 1000},
+            { creeps: ["test_creep","test_creep"], delay: 1300},
+            { creeps: ["test_creep","test_creep"], delay: 500},
+            { creeps: ["test_creep","test_creep"], delay: 100},
+            { creeps: ["test_creep","test_creep"], delay: 100},
+            { creeps: ["test_creep","test_creep"], delay: 100},
+            { creeps: ["test_creep","test_creep"], delay: 100},
+            { creeps: ["test_creep","test_creep"], delay: 100},
+            { creeps: ["test_creep","test_creep"], delay: 100},
+            { creeps: ["test_creep","test_creep"], delay: 100}
+           ] 
     },
     /**
      * @type {{name: string, archtype: {data: TowerData, stats: TowerStats, damageType: DamageData}}}
@@ -57,7 +68,7 @@ export default {
         "test_tower1": {
             name: "test_tower1",
             data: new TowerData(0, "test_tower1", "Tower_1Barrel", [{x: 15, y: 30}], 0),
-            stats: new TowerStats(150, 70, 1800 * (Math.PI / 180), 2, false, tickLength),
+            stats: new TowerStats(150, 30, 1800 * (Math.PI / 180), 2, false, tickLength),
             damageData: new DamageData(1, 0, []),
             upgradeTree: new UpgradeTree()
         }
@@ -71,7 +82,7 @@ export default {
     CREEP_PREFABS: {
         "test_creep": {
             data: new CreepData(0,"test_creep", "Creep_1_RED", []),
-            stats: new CreepStats(100,120,270,true,50,tickLength),
+            stats: new CreepStats(100,50,270,true,50,tickLength),
             collider: new Collider([{x: -30, y: -30}, {x: -30, y: 30}, {x: 30, y: 30}, {x: 30, y: -30}], {x: 0, y: 0})
         }
     }

--- a/revelations/client/src/engine/systems/controlTowers.js
+++ b/revelations/client/src/engine/systems/controlTowers.js
@@ -49,12 +49,44 @@ const priorityHeuristics = {
     First: (creepA, creepB, manager) => {
         const distA = getDistanceToTarget(creepA, manager);
         const distB = getDistanceToTarget(creepB, manager);
-        return distA < distB ? creepA : creepB;
+    
+        if(distA < distB){
+            return creepA;
+        }
+        else if(distA > distB){
+            return creepB;
+        }
+        else{
+            const euclidA = Math.sqrt((creepA.transform.position.x - creepA.data.target.position.x)**2+(creepA.transform.position.y - creepA.data.target.position.y)**2)
+            const euclidB = Math.sqrt((creepB.transform.position.x - creepB.data.target.position.x)**2+(creepB.transform.position.y - creepB.data.target.position.y)**2)
+            if(euclidA > euclidB){
+                return creepB
+            }
+            else{
+                return creepA;
+            }
+        }
     },
     Last: (creepA, creepB, manager) => {
         const distA = getDistanceToTarget(creepA, manager);
         const distB = getDistanceToTarget(creepB, manager);
-        return distA > distB ? creepA : creepB;
+        
+        if(distA > distB){
+            return creepA;
+        }
+        else if(distA < distB){
+            return creepB;
+        }
+        else{
+            const euclidA = Math.sqrt((creepA.transform.position.x - creepA.data.target.position.x)**2+(creepA.transform.position.y - creepA.data.target.position.y)**2)
+            const euclidB = Math.sqrt((creepB.transform.position.x - creepB.data.target.position.x)**2+(creepB.transform.position.y - creepB.data.target.position.y)**2)
+            if(euclidA < euclidB){
+                return creepB
+            }
+            else{
+                return creepA;
+            }
+        }
     },
     
 }
@@ -115,8 +147,9 @@ function getCreepsInRange(tower, manager){
  */
 function selectNewTarget(tower, creepArray, manager){
     let current = creepArray[0];
+    const heuristic = priorityHeuristics[tower.data.priority];
     for(const creep of creepArray){
-        current = priorityHeuristics[tower.data.priority](current, creep, manager);
+        current = heuristic(current, creep, manager);
     }
 
     tower.data.target = current;
@@ -152,11 +185,14 @@ function controlTowers(manager){
     const towerDirectory = manager.gameState.towerDirectory;
     for(const id of Object.keys(towerDirectory)){
         const tower = towerDirectory[id];
-        // If tower has no target
-        if(tower.data.target === undefined){
+        // If tower has no target or target is destroyed
+        if(tower.data.target === undefined || !Object.keys(manager.gameState.creepDirectory).includes(tower.data.target.data.id.toString())){
             const c = getCreepsInRange(tower, manager);
             if(c.length > 0){
                 selectNewTarget(tower, c, manager);
+            }
+            else{
+                tower.data.target = undefined;
             }
         }
         else{

--- a/revelations/client/src/engine/systems/findPaths.js
+++ b/revelations/client/src/engine/systems/findPaths.js
@@ -205,7 +205,7 @@ function runPathfind(source, target, unwalkable, grid, sourceHeuristic, targetHe
     const pathData = data ? data : {};
     for(const loader of Object.entries(dataLoaders)){
         if(!pathData[loader[0]]){
-            loader[1](pathData, source, target, unwalkable, grid);
+            loader[1](pathData, target, source, unwalkable, grid);
         }
     }
     const open = [];

--- a/revelations/client/src/engine/systems/processTick.js
+++ b/revelations/client/src/engine/systems/processTick.js
@@ -34,7 +34,7 @@ function processTick(manager) {
         totalTime += waveData[i].delay;
 
         // Check the anticipated time vs wave time
-        if(manager.runtimeState.waveTime === totalTime){
+        if(Math.abs(manager.runtimeState.waveTime - totalTime) < 10){
             for(let sourceIndex = 0; sourceIndex < waveData[i].creeps.length; sourceIndex++){
                 if(waveData[i].creeps[sourceIndex] !== undefined){
                     const newId = 10000 + Object.keys(manager.gameState.creepDirectory).length;

--- a/revelations/client/src/engine/systems/spawnCreep.js
+++ b/revelations/client/src/engine/systems/spawnCreep.js
@@ -27,6 +27,7 @@ import Tile from "../Tile.js";
  * @returns {Void}
  */
 function spawnCreep(manager, id, archtype, source, path){
+
     // Get creep archtype
     archtype = GameEnums.CREEP_PREFABS[archtype];
 


### PR DESCRIPTION
Refactored findPaths to use target as the source of all loaders so the DijkstraMap will always originate from the source. Updated target priority heuristics to break tie breakers with euclidean distance to their target tile. Towers now correctly reselect a target upon the destruction of their current target